### PR TITLE
Correção para evitar que duplo click na busca da bigcontrolcenter maximize a tela

### DIFF
--- a/usr/share/bigbashview/framework/js/client-side-decorator.js
+++ b/usr/share/bigbashview/framework/js/client-side-decorator.js
@@ -26,18 +26,20 @@ document.addEventListener('DOMContentLoaded', function () {
         // Adds a mousedown event listener on the title bar
         var titleBar = document.getElementById('title-bar');
         titleBar.addEventListener('mousedown', function (event) {
-            const currentTime = new Date().getTime();
-            const timeSinceLastClick = currentTime - lastClickTime;
+            if (event.target.tagName.toLowerCase() !== 'input' && event.target.tagName.toLowerCase() !== 'i') {
+                const currentTime = new Date().getTime();
+                const timeSinceLastClick = currentTime - lastClickTime;
 
-            if (timeSinceLastClick < doubleClickDelay) {
-                // Detected double click
-                window.windowControl.maximize(); // Calls the method to maximize or restore the window
-                disableDragArea = true;
-                setTimeout(() => {
-                    disableDragArea = false;
-                }, 300);
+                if (timeSinceLastClick < doubleClickDelay) {
+                    // Detected double click
+                    window.windowControl.maximize(); // Calls the method to maximize or restore the window
+                    disableDragArea = true;
+                    setTimeout(() => {
+                        disableDragArea = false;
+                    }, 300);
+                }
+                lastClickTime = currentTime;
             }
-            lastClickTime = currentTime;
         });
         // End workaround for maximize window with double click
     });


### PR DESCRIPTION
## Descrição do bug:
Ao acessar o aplicativo Centro de Controle (BigControlCenter) e tentar selecionar texto utilizando a função de clique duplo dentro do campo de pesquisa, faz com que a janela seja maximizada.

## Passos para Reproduzir:

Acessar o aplicativo Centro de Controle
Clicar no campo Pesquisar
Digitar um texto, por exemplo "biglinux"
Clicar duas vezes com o botão esquerdo do mouse para selecionar a palavra
Comportamento Esperado:
O termo de busca ficar selecionado

## Comportamento Atual:
O sistema maximiza a janela

## Comportamento após o ajuste
Duplo click dentro do input faz com que o texto seja selecionado
No restante da barra de título o duplo click maximiza a tela
